### PR TITLE
chore: update mobile sdks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,5 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.bugsplat:bugsplat-android:1.0.0'
+  implementation 'com.bugsplat:bugsplat-android:1.2.0'
 }

--- a/ios/BugsplatExpo.podspec
+++ b/ios/BugsplatExpo.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-CMD
     mkdir -p Frameworks
     if [ ! -d "Frameworks/BugSplat.xcframework" ]; then
-      curl -sL -o BugSplat.xcframework.zip "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v3.1.0/BugSplat.xcframework.zip"
+      curl -sL -o BugSplat.xcframework.zip "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v3.1.1/BugSplat.xcframework.zip"
       unzip -o BugSplat.xcframework.zip -d Frameworks
       rm -f BugSplat.xcframework.zip
     fi


### PR DESCRIPTION
## Summary
- Updates bugsplat-apple from v3.1.0 to v3.1.1 in the podspec download URL

## Test plan
- [x] Run `pod install` in the example app and verify the xcframework downloads correctly
- [x] Build and run on iOS to verify crash reporting works

🤖 Generated with [Claude Code](https://claude.com/claude-code)