### PR TITLE
feat: forward attributes to native crash reporters

### DIFF
--- a/android/src/main/java/expo/modules/bugsplatexpo/BugsplatExpoModule.kt
+++ b/android/src/main/java/expo/modules/bugsplatexpo/BugsplatExpoModule.kt
@@ -140,32 +140,25 @@ class BugsplatExpoModule : Module() {
       attributes["userName"] = name
       attributes["userEmail"] = email
 
-      // Re-init BugSplatBridge with updated attributes (idempotent)
       if (initialized) {
-        BugSplatBridge.initBugSplat(
-          currentActivity,
-          database,
-          applicationName,
-          applicationVersion,
-          attributes,
-          attachments
-        )
+        BugSplatBridge.setAttribute("userName", name)
+        BugSplatBridge.setAttribute("userEmail", email)
       }
     }
 
     Function("setAttribute") { key: String, value: String ->
       attributes[key] = value
 
-      // Re-init BugSplatBridge with updated attributes (idempotent)
       if (initialized) {
-        BugSplatBridge.initBugSplat(
-          currentActivity,
-          database,
-          applicationName,
-          applicationVersion,
-          attributes,
-          attachments
-        )
+        BugSplatBridge.setAttribute(key, value)
+      }
+    }
+
+    Function("removeAttribute") { key: String ->
+      attributes.remove(key)
+
+      if (initialized) {
+        BugSplatBridge.removeAttribute(key)
       }
     }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { init, post, setUser, setAttribute, crash, nativeAvailable, ErrorBoundary } from '@bugsplat/expo';
+import { init, post, setUser, setAttribute, removeAttribute, crash, nativeAvailable, ErrorBoundary } from '@bugsplat/expo';
 import { Button, Image, ScrollView, Text, View, StyleSheet, TextInput } from 'react-native';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -14,6 +14,9 @@ function BuggyComponent() {
 export default function App() {
   const [status, setStatus] = useState('Not initialized');
   const [database, setDatabase] = useState(DATABASE);
+  const [attrKey, setAttrKey] = useState('environment');
+  const [attrValue, setAttrValue] = useState('development');
+  const [activeAttributes, setActiveAttributes] = useState<Record<string, string>>({});
   const [triggerRenderError, setTriggerRenderError] = useState(false);
 
   const handleInit = async () => {
@@ -43,8 +46,23 @@ export default function App() {
   };
 
   const handleSetAttribute = () => {
-    setAttribute('environment', 'development');
-    setStatus('Attribute set!');
+    if (!attrKey.trim()) {
+      setStatus('Attribute key cannot be empty');
+      return;
+    }
+    setAttribute(attrKey, attrValue);
+    setActiveAttributes((prev) => ({ ...prev, [attrKey]: attrValue }));
+    setStatus(`Attribute set: ${attrKey} = ${attrValue}`);
+  };
+
+  const handleRemoveAttribute = (key: string) => {
+    removeAttribute(key);
+    setActiveAttributes((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setStatus(`Attribute removed: ${key}`);
   };
 
   const handleCrash = () => {
@@ -87,6 +105,32 @@ export default function App() {
           <View style={styles.buttonRow}>
             <Button title="Set Attribute" onPress={handleSetAttribute} />
           </View>
+        </View>
+
+        <View style={styles.group}>
+          <Text style={styles.groupHeader}>Attributes</Text>
+          <TextInput
+            style={styles.input}
+            value={attrKey}
+            onChangeText={setAttrKey}
+            placeholder="Attribute key"
+          />
+          <TextInput
+            style={[styles.input, { marginTop: 8 }]}
+            value={attrValue}
+            onChangeText={setAttrValue}
+            placeholder="Attribute value"
+          />
+          {Object.entries(activeAttributes).map(([key, value]) => (
+            <View key={key} style={styles.attributeRow}>
+              <Text style={styles.attributeText}>{key}: {value}</Text>
+              <Button title="Remove" onPress={() => handleRemoveAttribute(key)} color="red" />
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.group}>
+          <Text style={styles.groupHeader}>Native Crash</Text>
           <View style={styles.buttonRow}>
             <Button
               title="Test Crash"
@@ -168,6 +212,19 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 10,
     fontSize: 16,
+  },
+  attributeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 8,
+    paddingVertical: 4,
+    borderTopWidth: 1,
+    borderTopColor: '#eee',
+  },
+  attributeText: {
+    fontSize: 14,
+    flex: 1,
   },
   disabledHint: {
     color: '#999',

--- a/ios/BugsplatExpoModule.swift
+++ b/ios/BugsplatExpoModule.swift
@@ -148,6 +148,11 @@ public class BugsplatExpoModule: Module {
       _ = BugSplat.shared().set(value, for: key)
     }
 
+    Function("removeAttribute") { (key: String) in
+      self.attributes.removeValue(forKey: key)
+      _ = BugSplat.shared().set(nil, for: key)
+    }
+
     Function("crash") {
       let array = NSArray()
       _ = array.object(at: 99)

--- a/src/BugsplatExpo.ts
+++ b/src/BugsplatExpo.ts
@@ -115,6 +115,20 @@ export function setAttribute(key: string, value: string): void {
 }
 
 /**
+ * Remove a custom attribute so it is no longer included in crash reports.
+ */
+export function removeAttribute(key: string): void {
+  if (nativeAvailable) {
+    BugsplatExpoModule!.removeAttribute(key);
+    return;
+  }
+  delete jsAttributes[key];
+  if (jsClient) {
+    jsClient.setDefaultAttributes(jsAttributes);
+  }
+}
+
+/**
  * Trigger a test crash. Useful for verifying BugSplat integration.
  * Requires a development build with native modules — no-op in Expo Go.
  */

--- a/src/BugsplatExpo.web.ts
+++ b/src/BugsplatExpo.web.ts
@@ -96,6 +96,15 @@ export function setAttribute(key: string, _value: string): void {
 }
 
 /**
+ * Remove a custom attribute. No-op on web.
+ */
+export function removeAttribute(key: string): void {
+  console.warn(
+    `[@bugsplat/expo] removeAttribute('${key}') is not supported on web.`
+  );
+}
+
+/**
  * Trigger a test crash by throwing an unhandled error.
  */
 export function crash(): void {

--- a/src/BugsplatExpoModule.ts
+++ b/src/BugsplatExpoModule.ts
@@ -14,6 +14,7 @@ export interface BugsplatExpoNativeModule {
   ): Promise<{ success: boolean; error?: string }>;
   setUser(name: string, email: string): void;
   setAttribute(key: string, value: string): void;
+  removeAttribute(key: string): void;
   crash(): void;
 }
 

--- a/src/__tests__/BugsplatExpo.expoGo.test.ts
+++ b/src/__tests__/BugsplatExpo.expoGo.test.ts
@@ -22,7 +22,7 @@ jest.mock('@bugsplat/react', () => ({
   init: mockInitReact,
 }));
 
-import { init, post, setUser, setAttribute, crash } from '../BugsplatExpo';
+import { init, post, setUser, setAttribute, removeAttribute, crash } from '../BugsplatExpo';
 
 describe('BugsplatExpo (Expo Go / JS fallback)', () => {
   let warnSpy: jest.SpyInstance;
@@ -162,6 +162,17 @@ describe('BugsplatExpo (Expo Go / JS fallback)', () => {
       setAttribute('build', '42');
       expect(mockBugSplatInstance.setDefaultAttributes).toHaveBeenLastCalledWith(
         expect.objectContaining({ env: 'staging', build: '42' })
+      );
+    });
+  });
+
+  describe('removeAttribute', () => {
+    it('removes attribute from JS client after init', async () => {
+      await init('test-db', 'MyApp', '1.0.0');
+      setAttribute('env', 'staging');
+      removeAttribute('env');
+      expect(mockBugSplatInstance.setDefaultAttributes).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({ env: 'staging' })
       );
     });
   });

--- a/src/__tests__/BugsplatExpo.test.ts
+++ b/src/__tests__/BugsplatExpo.test.ts
@@ -3,6 +3,7 @@ const mockModule = {
   post: jest.fn().mockResolvedValue({ success: true }),
   setUser: jest.fn(),
   setAttribute: jest.fn(),
+  removeAttribute: jest.fn(),
   crash: jest.fn(),
 };
 
@@ -16,7 +17,7 @@ jest.mock('@bugsplat/react', () => ({
   init: mockInitReact,
 }));
 
-import { init, post, setUser, setAttribute, crash } from '../BugsplatExpo';
+import { init, post, setUser, setAttribute, removeAttribute, crash } from '../BugsplatExpo';
 
 describe('BugsplatExpo (native)', () => {
   beforeEach(() => {
@@ -102,6 +103,13 @@ describe('BugsplatExpo (native)', () => {
     it('calls native setAttribute', () => {
       setAttribute('version', '2.0');
       expect(mockModule.setAttribute).toHaveBeenCalledWith('version', '2.0');
+    });
+  });
+
+  describe('removeAttribute', () => {
+    it('calls native removeAttribute', () => {
+      removeAttribute('version');
+      expect(mockModule.removeAttribute).toHaveBeenCalledWith('version');
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export type {
   BugSplatPluginOptions,
 } from './BugsplatExpo.types';
 
-export { init, post, setUser, setAttribute, crash, nativeAvailable } from './BugsplatExpo';
+export { init, post, setUser, setAttribute, removeAttribute, crash, nativeAvailable } from './BugsplatExpo';
 
 export { ErrorBoundary, useErrorHandler, withErrorBoundary } from './web';


### PR DESCRIPTION
## Summary

- **Android**: Replace the workaround that re-initialized the entire Crashpad handler on every `setAttribute`/`setUser` call with direct `BugSplatBridge.setAttribute()` calls (available since `bugsplat-android` 1.2.0)
- **iOS**: Add `removeAttribute` support via `BugSplat.shared().set(nil, for:)`
- Add `removeAttribute` to the full API surface: native modules (Android/iOS), JS, web stub, and TypeScript interface
- Add test coverage for `removeAttribute` on both native and Expo Go paths

## Test plan

- [x] All 69 existing + new tests pass
- [x] Build and run on Android — verify `setAttribute` sets a Crashpad annotation visible in native crash reports
- [x] Build and run on iOS — verify `setAttribute` and `removeAttribute` work with BugSplat Apple SDK
- [x] Test `removeAttribute` clears attributes from subsequent crash reports

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)