### PR TITLE
fix: error boundary component stack attachment

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,10 +25,10 @@
     },
     "..": {
       "name": "@bugsplat/expo",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsplat/react": "^2.0.0"
+        "@bugsplat/react": "^2.1.0"
       },
       "devDependencies": {
         "@types/react": "~19.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsplat/react": "^2.0.0"
+        "@bugsplat/react": "^2.1.0"
       },
       "devDependencies": {
         "@types/react": "~19.1.1",
@@ -2271,15 +2271,15 @@
       "peer": true
     },
     "node_modules/@bugsplat/react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/react/-/react-2.0.0.tgz",
-      "integrity": "sha512-7+VCBxdAXfOdBKtexLTsoNve1Uml4wcmFX/wIR6db/L3xMI3StYelerKd44m/muwvXLVYLmZZmCJcxrfJqjXLA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsplat/react/-/react-2.1.0.tgz",
+      "integrity": "sha512-7P2w2nDcKO0CovQdxgmX4dQajv3fWs//i5r9Q7q91mxJfKNTObNUvJ3/GxBriHlYwZbNcfk55TyKFFXqS9M5lA==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
       "dependencies": {
-        "bugsplat": "^9.0.0"
+        "bugsplat": "^9.1.0"
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -5340,9 +5340,9 @@
       "license": "MIT"
     },
     "node_modules/bugsplat": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bugsplat/-/bugsplat-9.0.1.tgz",
-      "integrity": "sha512-VjfukkURuvswE6SAQg+4APtqDEJliW+OOZ2OR1pUsAQnvUYe75eGpXFMqvU2bLE1abOc9GVSv+lI2LGrJv75RQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bugsplat/-/bugsplat-9.1.0.tgz",
+      "integrity": "sha512-QIfY6kMtlMwJQz2Beg42QJ65TgkKP49jv5zBVCX2X86CDdCRFY0i/B9s1k3aqElJMRLVkiWxUut6FRTn2Xx5fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsplat/react": "^2.1.0"
+        "@bugsplat/react": "^2.1.0",
+        "base-64": "^1.0.0"
       },
       "devDependencies": {
+        "@types/base-64": "^1.0.2",
         "@types/react": "~19.1.1",
         "expo": "~55.0.8",
         "expo-module-scripts": "^55.0.2",
@@ -4058,6 +4060,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/base-64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
+      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5136,6 +5145,12 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://github.com/BugSplat-Git/bugsplat-expo#readme",
   "dependencies": {
-    "@bugsplat/react": "^2.0.0"
+    "@bugsplat/react": "^2.1.0"
   },
   "devDependencies": {
     "@types/react": "~19.1.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
   "license": "MIT",
   "homepage": "https://github.com/BugSplat-Git/bugsplat-expo#readme",
   "dependencies": {
-    "@bugsplat/react": "^2.1.0"
+    "@bugsplat/react": "^2.1.0",
+    "base-64": "^1.0.0"
   },
   "devDependencies": {
+    "@types/base-64": "^1.0.2",
     "@types/react": "~19.1.1",
     "expo": "~55.0.8",
     "expo-module-scripts": "^55.0.2",
@@ -47,10 +49,10 @@
     "ts-jest": "^29.4.6"
   },
   "peerDependencies": {
+    "@bugsplat/symbol-upload": "*",
     "expo": "*",
     "react": "*",
-    "react-native": "*",
-    "@bugsplat/symbol-upload": "*"
+    "react-native": "*"
   },
   "peerDependenciesMeta": {
     "@bugsplat/symbol-upload": {

--- a/src/BugsplatExpo.ts
+++ b/src/BugsplatExpo.ts
@@ -1,5 +1,10 @@
-import { appScope, type BugSplat, init as initReact } from '@bugsplat/react';
-import type { BugSplatAttachment } from 'bugsplat';
+import {
+  appScope,
+  type BugSplat,
+  type BugSplatAttachment,
+  init as initReact,
+} from '@bugsplat/react';
+import { encode as base64Encode } from 'base-64';
 
 import type {
   BugSplatFeedbackOptions,
@@ -15,18 +20,6 @@ export const nativeAvailable = BugsplatExpoModule != null;
 let jsClient: BugSplat | null = null;
 const jsAttributes: Record<string, string> = {};
 
-function utf8ToBase64(text: string): string {
-  const NodeBuffer = (
-    globalThis as {
-      Buffer?: { from(s: string, enc: string): { toString(enc: string): string } };
-    }
-  ).Buffer;
-  if (NodeBuffer) {
-    return NodeBuffer.from(text, 'utf-8').toString('base64');
-  }
-  return btoa(unescape(encodeURIComponent(text)));
-}
-
 /**
  * React Native-compatible componentStack attachment builder. RN's FormData
  * polyfill can't serialize browser `Blob`s, so we hand it a `data:` URI inside
@@ -39,7 +32,7 @@ function rnCreateComponentStackAttachment(
   return {
     filename: 'componentStack.txt',
     data: {
-      uri: `data:text/plain;base64,${utf8ToBase64(componentStack)}`,
+      uri: `data:text/plain;base64,${base64Encode(componentStack)}`,
       type: 'text/plain',
     },
   };

--- a/src/BugsplatExpo.ts
+++ b/src/BugsplatExpo.ts
@@ -1,4 +1,5 @@
-import { type BugSplat, init as initReact } from '@bugsplat/react';
+import { appScope, type BugSplat, init as initReact } from '@bugsplat/react';
+import type { BugSplatAttachment } from 'bugsplat';
 
 import type {
   BugSplatFeedbackOptions,
@@ -13,6 +14,36 @@ export const nativeAvailable = BugsplatExpoModule != null;
 
 let jsClient: BugSplat | null = null;
 const jsAttributes: Record<string, string> = {};
+
+function utf8ToBase64(text: string): string {
+  const NodeBuffer = (
+    globalThis as {
+      Buffer?: { from(s: string, enc: string): { toString(enc: string): string } };
+    }
+  ).Buffer;
+  if (NodeBuffer) {
+    return NodeBuffer.from(text, 'utf-8').toString('base64');
+  }
+  return btoa(unescape(encodeURIComponent(text)));
+}
+
+/**
+ * React Native-compatible componentStack attachment builder. RN's FormData
+ * polyfill can't serialize browser `Blob`s, so we hand it a `data:` URI inside
+ * the `{ uri, type }` file-ref shape that RN's fetch uploads as a real file
+ * part.
+ */
+function rnCreateComponentStackAttachment(
+  componentStack: string
+): BugSplatAttachment {
+  return {
+    filename: 'componentStack.txt',
+    data: {
+      uri: `data:text/plain;base64,${utf8ToBase64(componentStack)}`,
+      type: 'text/plain',
+    },
+  };
+}
 
 function applyDefaults(client: BugSplat, options?: BugSplatInitOptions): void {
   if (options?.appKey) client.setDefaultAppKey(options.appKey);
@@ -42,6 +73,11 @@ export async function init(
   version: string,
   options?: BugSplatInitOptions
 ): Promise<void> {
+  // Tell bugsplat-react's ErrorBoundary how to build its componentStack
+  // attachment on React Native. Set synchronously before any awaits so an
+  // ErrorBoundary that catches during startup doesn't race the default.
+  appScope.setCreateComponentStackAttachment(rnCreateComponentStackAttachment);
+
   if (nativeAvailable) {
     await BugsplatExpoModule!.init(database, application, version, options as Record<string, unknown>);
     initReact({ database, application, version })((client) => {

--- a/src/__tests__/BugsplatExpo.expoGo.test.ts
+++ b/src/__tests__/BugsplatExpo.expoGo.test.ts
@@ -22,8 +22,13 @@ const mockInitReact = jest.fn().mockReturnValue(
   }
 );
 
+const mockSetCreateComponentStackAttachment = jest.fn();
+
 jest.mock('@bugsplat/react', () => ({
   init: mockInitReact,
+  appScope: {
+    setCreateComponentStackAttachment: mockSetCreateComponentStackAttachment,
+  },
 }));
 
 import {

--- a/src/__tests__/BugsplatExpo.test.ts
+++ b/src/__tests__/BugsplatExpo.test.ts
@@ -31,8 +31,13 @@ const mockInitReact = jest.fn().mockReturnValue(
   }
 );
 
+const mockSetCreateComponentStackAttachment = jest.fn();
+
 jest.mock('@bugsplat/react', () => ({
   init: mockInitReact,
+  appScope: {
+    setCreateComponentStackAttachment: mockSetCreateComponentStackAttachment,
+  },
 }));
 
 import {
@@ -67,6 +72,20 @@ describe('BugsplatExpo (native)', () => {
         database: 'test-db',
         application: 'MyApp',
         version: '1.0.0',
+      });
+    });
+
+    it('installs an RN-compatible componentStack attachment builder on appScope', async () => {
+      await init('test-db', 'MyApp', '1.0.0');
+      expect(mockSetCreateComponentStackAttachment).toHaveBeenCalledTimes(1);
+      const [builder] = mockSetCreateComponentStackAttachment.mock.calls[0];
+      const attachment = builder('at BuggyComponent\n  at ErrorBoundary');
+      expect(attachment).toEqual({
+        filename: 'componentStack.txt',
+        data: {
+          uri: expect.stringMatching(/^data:text\/plain;base64,/),
+          type: 'text/plain',
+        },
       });
     });
 


### PR DESCRIPTION
## Summary

`@bugsplat/expo@0.5.0` unified the React helpers by re-exporting `@bugsplat/react`'s `<ErrorBoundary>` for every platform. On React Native that path failed with `TypeError: Network request failed` because `@bugsplat/react@<=2.0` wrapped the componentStack in a browser-style `Blob`, which RN's FormData polyfill can't serialize — the multipart body never assembled and `fetch` rejected before the request left the device.

**Resolution chain:**
- [bugsplat-js#78](https://github.com/BugSplat-Git/bugsplat-js/pull/78) (merged, published as `9.1.0`) — added `BugSplatFileRef` to the attachment union so RN consumers can upload by URI.
- [bugsplat-react#21](https://github.com/BugSplat-Git/bugsplat-react/pull/21) (merged, published as `2.1.0`) — moved componentStack attachment construction behind a `Scope`-injected builder with a web-shaped default, so platform-aware wrappers can override it in one place.

**What this PR does:**

1. Bumps the `@bugsplat/react` dep to `^2.1.0`.
2. Adds `rnCreateComponentStackAttachment` — the RN file-ref builder (base64 `data:` URI in the `{ uri, type }` shape RN's FormData uploads as a real multipart file part).
3. Installs it on `appScope` via `setCreateComponentStackAttachment(…)` at the top of `init()`, synchronously before any awaits so an ErrorBoundary that catches during startup doesn't race the default.
4. Adds `base-64` as a dependency — small, pure-JS encoder that works on any runtime. Avoids relying on `btoa`/`Buffer`, neither of which is guaranteed on RN/Hermes.
5. Extends the Jest mocks in the native + Expo Go suites to expose `appScope.setCreateComponentStackAttachment`, plus a round-trip test that verifies the installed builder emits the RN file-ref shape.
6. Imports `BugSplatAttachment` from `@bugsplat/react` rather than `bugsplat` directly, so our emitted `.d.ts` doesn't reference a transitive dep (pnpm/strict-resolution safety).

## Test plan

- [x] 74 Jest tests green (new `installs an RN-compatible componentStack attachment builder on appScope` assertion)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean; emitted `build/BugsplatExpo.d.ts` only references local types
- [x] End-to-end verified on Pixel 7 API 35 emulator with registry-installed `@bugsplat/react@2.1.0`: tapping "Trigger Render Error" in the example app posts to BugSplat with `crash_id` and `componentStack.txt` shows up as a real file attachment in the dashboard. Multiple consecutive taps all succeed.

## Ship plan

Merge → `npm version patch` → `npm publish` → `@bugsplat/expo@0.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)