### PR TITLE
feat: hang detection (ANR) — Android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ import { crash } from '@bugsplat/expo';
 crash();
 ```
 
+### Hang Detection (ANR)
+
+On Android 11+ (API 30+), `@bugsplat/expo` automatically detects and reports Application Not Responding (ANR) events. Historical ANRs from previous app sessions are checked each time `init()` is called and reported with `crash_type = Android.ANR`. No additional configuration is required.
+
+Hang detection for iOS is not yet supported and will land in a future release.
+
+To test ANR detection end-to-end, call `hang()` — it blocks the native main thread in an infinite loop so the system flags it as an ANR:
+
+```typescript
+import { hang } from '@bugsplat/expo';
+
+// Android only — blocks the UI thread until the system ANRs.
+// iOS / Expo Go / web log a warning instead.
+hang();
+```
+
+Testing ANRs requires a **release build** on a physical device or a `google_apis` emulator image — debug builds and the Play Store emulator image intercept or suppress ANR exit info.
+
 ### Error Boundary
 
 Wrap your component tree in `<ErrorBoundary>` to catch React render errors and report them to BugSplat automatically. Works identically on iOS, Android, and Web.
@@ -264,6 +282,10 @@ Set a custom attribute. Note: not supported on web.
 ### `crash()`
 
 Trigger a test crash to verify integration.
+
+### `hang()`
+
+Trigger a test hang by blocking the native main thread. Used to verify ANR detection on Android. Android-only — logs a warning on iOS, Expo Go, and web.
 
 ## Expo Go
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,5 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.bugsplat:bugsplat-android:1.2.0'
+  implementation 'com.bugsplat:bugsplat-android:1.3.0'
 }

--- a/android/src/main/java/expo/modules/bugsplatexpo/BugsplatExpoModule.kt
+++ b/android/src/main/java/expo/modules/bugsplatexpo/BugsplatExpoModule.kt
@@ -165,5 +165,14 @@ class BugsplatExpoModule : Module() {
     Function("crash") {
       BugSplatBridge.crash()
     }
+
+    Function("hang") {
+      // BugSplatBridge.hang() blocks the calling thread in a native infinite
+      // loop — ANR detection requires hanging the main/UI thread, so dispatch
+      // there and return immediately to avoid blocking the JS bridge.
+      appContext.currentActivity?.runOnUiThread {
+        BugSplatBridge.hang()
+      } ?: throw Exceptions.MissingActivity()
+    }
   }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { init, post, setUser, setAttribute, removeAttribute, crash, nativeAvailable, ErrorBoundary } from '@bugsplat/expo';
+import { init, post, setUser, setAttribute, removeAttribute, crash, hang, nativeAvailable, ErrorBoundary } from '@bugsplat/expo';
+import { Platform } from 'react-native';
 import { Button, Image, ScrollView, Text, View, StyleSheet, TextInput } from 'react-native';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -67,6 +68,11 @@ export default function App() {
 
   const handleCrash = () => {
     crash();
+  };
+
+  const handleHang = () => {
+    setStatus('Hanging main thread — app should ANR shortly…');
+    hang();
   };
 
   return (
@@ -141,6 +147,27 @@ export default function App() {
             {(!nativeAvailable || __DEV__) && (
               <Text style={styles.disabledHint}>
                 Native crash testing requires a release build
+              </Text>
+            )}
+          </View>
+        </View>
+
+        <View style={styles.group}>
+          <Text style={styles.groupHeader}>Hang Detection (ANR)</Text>
+          <View style={styles.buttonRow}>
+            <Button
+              title="Trigger Hang"
+              onPress={handleHang}
+              color={nativeAvailable && !__DEV__ && Platform.OS === 'android' ? 'red' : 'gray'}
+              disabled={!nativeAvailable || __DEV__ || Platform.OS !== 'android'}
+            />
+            {Platform.OS !== 'android' ? (
+              <Text style={styles.disabledHint}>
+                Hang detection is currently Android-only
+              </Text>
+            ) : (!nativeAvailable || __DEV__) && (
+              <Text style={styles.disabledHint}>
+                Hang testing requires a release build
               </Text>
             )}
           </View>

--- a/ios/BugsplatExpoModule.swift
+++ b/ios/BugsplatExpoModule.swift
@@ -157,5 +157,9 @@ public class BugsplatExpoModule: Module {
       let array = NSArray()
       _ = array.object(at: 99)
     }
+
+    Function("hang") {
+      NSLog("[BugsplatExpo] hang() is not yet supported on iOS — tracking in bugsplat-apple.")
+    }
   }
 }

--- a/src/BugsplatExpo.ts
+++ b/src/BugsplatExpo.ts
@@ -180,3 +180,18 @@ export function crash(): void {
   }
   console.warn('[@bugsplat/expo] crash() requires native modules. Use a development build to test native crashes.');
 }
+
+/**
+ * Trigger a test hang by blocking the native main thread in an infinite loop.
+ * Useful for verifying ANR (Application Not Responding) detection on Android.
+ *
+ * Currently Android-only — iOS and Expo Go log a warning instead. Requires a
+ * release build; debuggers intercept ANRs in debug builds.
+ */
+export function hang(): void {
+  if (nativeAvailable) {
+    BugsplatExpoModule!.hang();
+    return;
+  }
+  console.warn('[@bugsplat/expo] hang() requires native modules. Use a development build to test ANR detection.');
+}

--- a/src/BugsplatExpo.web.ts
+++ b/src/BugsplatExpo.web.ts
@@ -142,3 +142,10 @@ export function removeAttribute(key: string): void {
 export function crash(): void {
   throw new Error('BugSplat test crash');
 }
+
+/**
+ * Trigger a test hang. Hang detection is a native-only feature — no-op on web.
+ */
+export function hang(): void {
+  console.warn('[@bugsplat/expo] hang() is not supported on web.');
+}

--- a/src/BugsplatExpoModule.ts
+++ b/src/BugsplatExpoModule.ts
@@ -16,6 +16,7 @@ export interface BugsplatExpoNativeModule {
   setAttribute(key: string, value: string): void;
   removeAttribute(key: string): void;
   crash(): void;
+  hang(): void;
 }
 
 export default requireOptionalNativeModule<BugsplatExpoNativeModule>('BugsplatExpo');

--- a/src/__tests__/BugsplatExpo.expoGo.test.ts
+++ b/src/__tests__/BugsplatExpo.expoGo.test.ts
@@ -34,6 +34,7 @@ import {
   setAttribute,
   removeAttribute,
   crash,
+  hang,
 } from '../BugsplatExpo';
 
 describe('BugsplatExpo (Expo Go / JS fallback)', () => {
@@ -194,6 +195,15 @@ describe('BugsplatExpo (Expo Go / JS fallback)', () => {
       crash();
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('crash() requires native modules')
+      );
+    });
+  });
+
+  describe('hang', () => {
+    it('logs a warning instead of hanging', () => {
+      hang();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('hang() requires native modules')
       );
     });
   });

--- a/src/__tests__/BugsplatExpo.test.ts
+++ b/src/__tests__/BugsplatExpo.test.ts
@@ -5,6 +5,7 @@ const mockModule = {
   setAttribute: jest.fn(),
   removeAttribute: jest.fn(),
   crash: jest.fn(),
+  hang: jest.fn(),
 };
 
 jest.mock('../BugsplatExpoModule', () => ({
@@ -43,6 +44,7 @@ import {
   setAttribute,
   removeAttribute,
   crash,
+  hang,
 } from '../BugsplatExpo';
 
 describe('BugsplatExpo (native)', () => {
@@ -221,6 +223,13 @@ describe('BugsplatExpo (native)', () => {
     it('calls native crash', () => {
       crash();
       expect(mockModule.crash).toHaveBeenCalled();
+    });
+  });
+
+  describe('hang', () => {
+    it('calls native hang', () => {
+      hang();
+      expect(mockModule.hang).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/BugsplatExpo.web.test.ts
+++ b/src/__tests__/BugsplatExpo.web.test.ts
@@ -29,6 +29,7 @@ import {
   setUser,
   setAttribute,
   crash,
+  hang,
 } from '../BugsplatExpo.web';
 
 describe('BugsplatExpo (web)', () => {
@@ -140,6 +141,17 @@ describe('BugsplatExpo (web)', () => {
   describe('crash', () => {
     it('throws an error', () => {
       expect(() => crash()).toThrow('BugSplat test crash');
+    });
+  });
+
+  describe('hang', () => {
+    it('warns that hang is not supported on web', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      hang();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('not supported on web')
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   setAttribute,
   removeAttribute,
   crash,
+  hang,
   nativeAvailable,
 } from './BugsplatExpo';
 


### PR DESCRIPTION
## Summary
- Bumps `com.bugsplat:bugsplat-android` 1.2.0 → 1.3.0, which automatically detects and reports historical ANRs via `ApplicationExitInfo` on Android 11+ each time `init()` is called (no additional config needed).
- Adds a cross-platform `hang()` test helper that blocks the native main thread on Android for end-to-end ANR verification. iOS / Expo Go / web log a warning.
- Wires a "Trigger Hang" button into the example app (release-build, Android-only).
- Verified end-to-end on a Pixel 7 API 35 emulator release build — ANR fired, was captured via `ApplicationExitInfo`, and uploaded by `AnrReporter` on the next `init()`.

Closes #15.

## Draft — awaiting iOS implementation
This PR is kept in draft while iOS hang detection lands upstream in [bugsplat-apple](https://github.com/BugSplat-Git/bugsplat-apple). The iOS Swift module currently no-ops `hang()` with an NSLog, matching the "not yet supported" contract in the TypeScript layer. Once the iOS SDK exposes a hang helper, a follow-up commit on this branch will wire it through and we can mark the PR ready for review.

## Test plan
- [x] `npm test` — 76/76 pass (added `hang` coverage to native, Expo Go, and web suites)
- [x] `npx tsc --noEmit` clean
- [x] Release build on Android 15 emulator (`google_apis` image): tap Init → tap Trigger Hang → system ANR dialog fires → relaunch → ANR report uploaded to BugSplat as `crash_type = Android.ANR`
- [ ] iOS hang verification — pending upstream SDK support

🤖 Generated with [Claude Code](https://claude.com/claude-code)